### PR TITLE
Make CSS work the HTTPS page

### DIFF
--- a/views/index.haml
+++ b/views/index.haml
@@ -1,7 +1,7 @@
 %html{'ng-app' => 'golfcal'}
   %head
     %title Golf.se - iCal
-    %link{:rel => :stylesheet, :text => "text/css", :href => "//yui.yahooapis.com/pure/0.5.0/pure-min.css"}
+    %link{:rel => :stylesheet, :text => "text/css", :href => "//cdnjs.cloudflare.com/ajax/libs/pure/0.5.0/pure-min.css"}
     %link{:rel => :stylesheet, :text => "text/css", :href => "style.css"}
     %meta{:name => "viewport", :content => "width=device-width, initial-scale=1"}
     %script{:src => "//ajax.googleapis.com/ajax/libs/angularjs/1.3.0-beta.14/angular.min.js"}


### PR DESCRIPTION
We have free SSL from Heroku on https://golfse.herokuapp.com/

https://yui.yahooapis.com has faulty SSL setup:

```
$ openssl s_client -connect yui.yahooapis.com:443
...
subject=/C=US/ST=California/L=Sunnyvale/O=Yahoo Inc./OU=Information Technology/CN=*.yimg.com
...
```
